### PR TITLE
可手动导出互助码

### DIFF
--- a/panel/public/run.html
+++ b/panel/public/run.html
@@ -42,6 +42,7 @@
                 <button id="jd_dreamFactory" class="cmd-btn" title="京喜工厂">京喜工厂</button>
                 <button id="jd_joy_reward" class="cmd-btn" title="宠汪汪积分兑换">宠汪汪积分兑换</button>
                 <button id="git_pull" title="更新脚本">更新脚本</button>
+                <button id="export_sharecodes" title="导出所有互助码">导出所有互助码</button>
                 <button id="hangup" title="重启挂机程序">重启挂机程序</button>
                 <button id="resetpwd" title="重置用户名密码">重置用户名密码</button>
                 <br/>
@@ -104,11 +105,14 @@
                 }, 1000);
             });
 
-            $('#hangup, #resetpwd, #git_pull').click(function() {
+            $('#hangup, #resetpwd, #export_sharecodes, #git_pull').click(function() {
                 let confirmTxt;
                 switch (this.id) {
                     case 'git_pull':
                         confirmTxt = '确认更新脚本文件？';
+                        break;
+                    case 'export_sharecodes':
+                        confirmTxt = '确认导出所有互助码？';
                         break;
                     case 'hangup':
                         confirmTxt = '确认重启挂机程序？';
@@ -133,7 +137,7 @@
                 }
                 editor.setValue('');
 
-                const cmd = this.id === 'git_pull' ? 'bash git_pull' : `bash jd ${this.id}`;
+                const cmd = this.id === 'git_pull' ? 'bash git_pull' : this.id === 'export_sharecodes' ? 'bash export_sharecodes' : `bash jd ${this.id}`;
                 $.post('./runCmd', {cmd: cmd}, function (data) {
                     editor.setValue(data.msg);
 


### PR DESCRIPTION
大佬，有一个问题想要问您：在用您的面板的时候，在手动脚本页面，执行脚本出错的情况下（例如执行jd_beauty），页面会显示"请先登录!"，然后就会返回到登录页面，我觉得这对我来说体验不算很好。想问问您有办法让它执行出错的时候也停留在当前页面，不提示"请先登录"吗？